### PR TITLE
Make results bool-compatible

### DIFF
--- a/Examples/TestJSON.ps1
+++ b/Examples/TestJSON.ps1
@@ -39,7 +39,7 @@ $expected = @"
 "@
 
 # True Result
-Test-Json -Value $actual -Referecnce $expected
+Test-Json -Value $actual -Reference $expected
 
 # False Result
-Test-Json -Value $actual -Referecnce '{}'
+Test-Json -Value $actual -Reference '{}'

--- a/Examples/TestJSON.ps1
+++ b/Examples/TestJSON.ps1
@@ -38,4 +38,8 @@ $expected = @"
 }
 "@
 
+# True Result
 Test-Json -Value $actual -Referecnce $expected
+
+# False Result
+Test-Json -Value $actual -Referecnce '{}'

--- a/Examples/TestJSON.ps1
+++ b/Examples/TestJSON.ps1
@@ -1,4 +1,4 @@
-﻿Import-Module ..\PSMatcher.psm1 -Force
+﻿Import-Module -Name "$PSScriptRoot\..\PSMatcher.psm1" -Force
 
 $actual = @"
 {
@@ -38,4 +38,4 @@ $expected = @"
 }
 "@
 
-Test-Json $actual $expected
+Test-Json -Value $actual -Referecnce $expected

--- a/PSMatcher.psd1
+++ b/PSMatcher.psd1
@@ -4,7 +4,7 @@
 RootModule = 'PSMatcher.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.1.0'
 
 # ID used to uniquely identify this module
 GUID = '0a1d5c08-32eb-4b57-91a0-e855845c5cd5'

--- a/PSMatcher.psm1
+++ b/PSMatcher.psm1
@@ -23,9 +23,9 @@ function New-BoolCompatibleResult {
 
     Process {
         $Result.Successful |
-            Add-Member -NotePropertyName Result -NotePropertyValue $result -TypeName NMatcher.Matching.Result -Force -PassThru |
             Add-Member -MemberType ScriptProperty -Name Successful -Value { $this.Result.Successful } -Force -PassThru |
-            Add-Member -MemberType ScriptProperty -Name ErrorMessage -Value { $this.Result.ErrorMessage } -Force -PassThru
+            Add-Member -MemberType ScriptProperty -Name ErrorMessage -Value { $this.Result.ErrorMessage } -Force -PassThru |
+            Add-Member -NotePropertyName Result -NotePropertyValue $result -TypeName NMatcher.Matching.Result -Force -PassThru
     }
 }
 

--- a/PSMatcher.psm1
+++ b/PSMatcher.psm1
@@ -9,12 +9,60 @@ $null = [System.Reflection.Assembly]::LoadFrom("$PSScriptRoot\$target\NMatcher.d
 $null = [System.Reflection.Assembly]::LoadFrom("$PSScriptRoot\$target\Newtonsoft.Json.dll")
 $null = [System.Reflection.Assembly]::LoadFrom("$PSScriptRoot\$target\Sprache.dll")
 
-function Test-Json {
+function New-BoolCompatibleResult {
+    [CmdletBinding()]
+    [OutputType([bool])]
     param(
-        $actual,
-        $test
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [NMatcher.Matching.Result]
+        $Result
     )
 
-    $m = New-Object NMatcher.Matcher
-    $m.MatchJson($actual, $test) #.Successful
+    Begin {
+        $displayProperties = @('Successful', 'ErrorMessage') -as [String[]]
+        $propertySet = New-Object -TypeName System.Management.Automation.PSPropertySet -ArgumentList 'DefaultPropertySet', $displayProperties
+        $ddpStandardMembers = @($propertySet) -as [System.Management.Automation.PSMemberInfo[]]
+    }
+
+    Process {
+        $Result.Successful |
+            Add-Member -NotePropertyName Result -NotePropertyValue $result -TypeName NMatcher.Matching.Result -Force -PassThru |
+            Add-Member -MemberType ScriptProperty -Name Successful -Value { $this.Result.Successful } -Force -PassThru |
+            Add-Member -MemberType ScriptProperty -Name ErrorMessage -Value { $this.Result.ErrorMessage } -Force -PassThru |
+            Add-Member -MemberType MemberSet -Name PSStandardMembers -Value $ddpStandardMembers -Force -PassThru
+    }
 }
+
+function Test-Json {
+    [CmdletBinding()]
+    [OutputType([bool])]
+    param(
+        [Parameter(
+            Mandatory,
+            ValueFromPipeline
+        )]
+        [Alias('Actual')]
+        [ValidateNotNullOrEmpty()]
+        $Value ,
+
+        [Parameter(
+            Mandatory
+        )]
+        [Alias('Test')]
+        [ValidateNotNullOrEmpty()]
+        $Referecnce
+    )
+
+    Begin {
+        $matcher = New-Object -TypeName NMatcher.Matcher
+    }
+
+    Process {
+        $matcher.MatchJson($Value, $Referecnce) | New-BoolCompatibleResult
+    }
+}
+
+Export-ModuleMember -Function Test-Json

--- a/PSMatcher.psm1
+++ b/PSMatcher.psm1
@@ -21,18 +21,11 @@ function New-BoolCompatibleResult {
         $Result
     )
 
-    Begin {
-        $displayProperties = @('Successful', 'ErrorMessage') -as [String[]]
-        $propertySet = New-Object -TypeName System.Management.Automation.PSPropertySet -ArgumentList 'DefaultPropertySet', $displayProperties
-        $ddpStandardMembers = @($propertySet) -as [System.Management.Automation.PSMemberInfo[]]
-    }
-
     Process {
         $Result.Successful |
             Add-Member -NotePropertyName Result -NotePropertyValue $result -TypeName NMatcher.Matching.Result -Force -PassThru |
             Add-Member -MemberType ScriptProperty -Name Successful -Value { $this.Result.Successful } -Force -PassThru |
-            Add-Member -MemberType ScriptProperty -Name ErrorMessage -Value { $this.Result.ErrorMessage } -Force -PassThru |
-            Add-Member -MemberType MemberSet -Name PSStandardMembers -Value $ddpStandardMembers -Force -PassThru
+            Add-Member -MemberType ScriptProperty -Name ErrorMessage -Value { $this.Result.ErrorMessage } -Force -PassThru
     }
 }
 

--- a/PSMatcher.psm1
+++ b/PSMatcher.psm1
@@ -46,7 +46,7 @@ function Test-Json {
         )]
         [Alias('Test')]
         [ValidateNotNullOrEmpty()]
-        $Referecnce
+        $Reference
     )
 
     Begin {
@@ -54,7 +54,7 @@ function Test-Json {
     }
 
     Process {
-        $matcher.MatchJson($Value, $Referecnce) | New-BoolCompatibleResult
+        $matcher.MatchJson($Value, $Reference) | New-BoolCompatibleResult
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ $expected = @"
 "@
 
 # True Result
-Test-Json -Value $actual -Referecnce $expected
+Test-Json -Value $actual -Reference $expected
 
 # False Result
-Test-Json -Value $actual -Referecnce '{}'
+Test-Json -Value $actual -Reference '{}'
 ```
 # Results
 ```

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It's here on the [PowerShell Gallery](https://www.powershellgallery.com/packages
 This PowerShell has been tested on Windows in both v5.1 and v6.0
 
 ```powershell
-Import-Module ..\PSMatcher.psm1 -Force
+Import-Module -Name "$PSScriptRoot\..\PSMatcher.psm1" -Force
 
 $actual = @"
 {
@@ -17,7 +17,7 @@ $actual = @"
         "zipCode" : "80-000",
         "meta" : {
             "name" : "foobar",
-            "shipping": 99.99,
+            "shipping": 99.99,            
             "enabled" : false,
             "_link" : "http://example.com?page=2",
             "_something" : null,
@@ -47,13 +47,18 @@ $expected = @"
 }
 "@
 
-Test-Json $actual $expected
+# True Result
+Test-Json -Value $actual -Referecnce $expected
+
+# False Result
+Test-Json -Value $actual -Referecnce '{}'
 ```
 # Results
 ```
-Successful ErrorMessage
----------- ------------
-      True
+Successful ErrorMessage                              Result                  
+---------- ------------                              ------                  
+      True                                           NMatcher.Matching.Result
+     False Expected value did not appear at path id. NMatcher.Matching.Result
 ```
 
 # In addition


### PR DESCRIPTION
The primary purpose of this PR is to ensure the result of the validation is usable directly as a `$true`/`$false` value.

Previously you had to use the `.Successful` property, because the implicit conversion of the `[Result]` object to `[bool]` is always `$true`.

Now, the object returned is a standard `[bool]`, extended with the ETS to include the original `[Result]` object (in case it's needed) as well as direct properties to access the `.Successful` and `.ErrorMessage` properties of the underlying `[Result]` object.

This means you can use it as you did the original object (if you were using the members) or you can use it directly in an `if` statement or other conditional.

In adding support for this I formalized the parameters a bit, added pipeline support, and updated the example code and README.